### PR TITLE
feat : login / signup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,8 @@
-import { ToastContainer } from 'react-toastify';
 import AppLayout from './components/layout/AppLayout';
-import 'react-toastify/dist/ReactToastify.css';
 
 function App() {
   return (
     <>
-      <ToastContainer
-        theme="dark"
-        autoClose={1000}
-        hideProgressBar
-        newestOnTop
-      />
       <AppLayout />
     </>
   );

--- a/src/api/firebase.ts
+++ b/src/api/firebase.ts
@@ -1,4 +1,13 @@
 import { FirebaseApp, getApp, initializeApp } from 'firebase/app';
+import {
+  GithubAuthProvider,
+  GoogleAuthProvider,
+  createUserWithEmailAndPassword,
+  getAuth,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  signOut,
+} from 'firebase/auth';
 
 export let app: FirebaseApp;
 
@@ -20,3 +29,33 @@ try {
 const firebase = initializeApp(firebaseConfig);
 
 export default firebase;
+
+const auth = getAuth(app);
+
+export async function createUser(email: string, password: string) {
+  await createUserWithEmailAndPassword(auth, email, password);
+}
+
+export async function socialLogin(providerName: string) {
+  let provider;
+  if (providerName === 'google') {
+    provider = new GoogleAuthProvider();
+  }
+
+  if (providerName === 'github') {
+    provider = new GithubAuthProvider();
+  }
+
+  await signInWithPopup(
+    auth,
+    provider as GoogleAuthProvider | GithubAuthProvider,
+  );
+}
+
+export async function Login(email: string, password: string) {
+  await signInWithEmailAndPassword(auth, email, password);
+}
+
+export async function logOut() {
+  await signOut(auth);
+}

--- a/src/components/LogoutButton.module.scss
+++ b/src/components/LogoutButton.module.scss
@@ -9,7 +9,6 @@
   border: none;
   align-items: center;
   justify-content: flex-start;
-  // margin-left: 80px;
   background-color: $background;
   color: $white;
   margin-top: auto;
@@ -29,8 +28,16 @@
     }
   }
 
+  &__imageIcon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+  }
+
   &__username {
     margin: 0 12px;
     font-weight: 300;
+    text-align: left;
+    padding-left: 5px;
   }
 }

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -1,14 +1,30 @@
+import { FaUserCircle } from 'react-icons/fa';
+import { toast } from 'react-toastify';
+import { useContext } from 'react';
+import { logOut } from '../api/firebase';
+import AuthContext from './context/AuthContext';
 import styles from './LogoutButton.module.scss';
 
 export default function LogoutButton() {
+  const { user } = useContext(AuthContext);
+
+  const handleLogout = async () => {
+    await logOut();
+    toast.success('로그아웃 되었습니다.');
+  };
+
   return (
-    <button className={styles.logOut__btn}>
+    <button className={styles.logOut__btn} type="button" onClick={handleLogout}>
       <div className={styles.logOut__btn__image}>
-        <img src="./vite.svg" alt="profile" />
+        {user?.photoURL ? (
+          <img src={user?.photoURL} alt="profile" />
+        ) : (
+          <FaUserCircle className={styles.logOut__btn__imageIcon} />
+        )}
       </div>
       <div className={styles.logOut__btn__username}>
-        <div>name</div>
-        <div>email</div>
+        <div>{user?.displayName ?? 'user'}</div>
+        <div>{user?.email ?? '@' + user?.uid?.slice(0, 5)}</div>
       </div>
     </button>
   );

--- a/src/components/Menu.module.scss
+++ b/src/components/Menu.module.scss
@@ -5,7 +5,6 @@
   align-items: center;
   justify-content: flex-start;
   padding: 12px;
-  // margin-left: 90px;
   border-radius: 30px;
   margin-bottom: 10px;
   font-size: 22px;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,14 @@
+import { Navigate } from 'react-router';
+import { useContext } from 'react';
+import AuthContext from './context/AuthContext';
+import { AuthProps } from '../type';
+
+export default function ProtectedRoute({ children }: AuthProps) {
+  const { user } = useContext(AuthContext);
+
+  if (!user) {
+    return <Navigate to="/users" replace />;
+  }
+
+  return children;
+}

--- a/src/components/context/AuthContext.tsx
+++ b/src/components/context/AuthContext.tsx
@@ -5,25 +5,26 @@ import { AuthProps } from '../../type';
 
 const AuthContext = createContext({
   user: null as User | null,
+  loading: true,
 });
 
 export const AuthContextProvider = ({ children }: AuthProps) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
   const auth = getAuth(app);
 
   useEffect(() => {
-    onAuthStateChanged(auth, (user) => {
-      if (user) {
-        setCurrentUser(user);
-      } else {
-        setCurrentUser(null);
-      }
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setCurrentUser(user);
+      setLoading(false);
     });
+
+    return () => unsubscribe();
   }, [auth]);
 
   return (
-    <AuthContext.Provider value={{ user: currentUser }}>
+    <AuthContext.Provider value={{ user: currentUser, loading }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,28 +1,51 @@
 import { Outlet } from 'react-router';
 import { Link } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import { useContext } from 'react';
+import AuthContext from '../context/AuthContext';
 import Menu from '../Menu';
 import LogoutButton from '../LogoutButton';
+import Loader from '../loader/Loader';
+import 'react-toastify/dist/ReactToastify.css';
 import styles from './AppLayout.module.scss';
 
 export default function AppLayout() {
+  const { user, loading } = useContext(AuthContext);
+
+  if (loading) {
+    return <Loader />;
+  }
+
   return (
-    <div className={styles.container}>
-      <header className={styles.left__section__wrapper}>
-        <section className={styles.left__section}>
-          <div className={styles.left__sectionFixed}>
-            <Link to="/" className={styles.logo}>
-              <div className={styles.logoPill}>
-                <img src="./logo.png" alt="logo" width={60} height={60} />
+    <>
+      <ToastContainer
+        theme="dark"
+        autoClose={1000}
+        hideProgressBar
+        newestOnTop
+      />
+      {user ? (
+        <div className={styles.container}>
+          <header className={styles.left__section__wrapper}>
+            <section className={styles.left__section}>
+              <div className={styles.left__sectionFixed}>
+                <Link to="/" className={styles.logo}>
+                  <div className={styles.logoPill}>
+                    <img src="./logo.png" alt="logo" width={60} height={60} />
+                  </div>
+                </Link>
               </div>
-            </Link>
+            </section>
+            <Menu />
+            <LogoutButton />
+          </header>
+          <div className={styles.right__section}>
+            <Outlet />
           </div>
-        </section>
-        <Menu />
-        <LogoutButton />
-      </header>
-      <div className={styles.right__section}>
+        </div>
+      ) : (
         <Outlet />
-      </div>
-    </div>
+      )}
+    </>
   );
 }

--- a/src/components/loader/Loader.module.scss
+++ b/src/components/loader/Loader.module.scss
@@ -1,0 +1,28 @@
+@import '../../style.scss';
+
+.loader {
+  width: 48px;
+  height: 48px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  border: 5px solid $primaryColor;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+  z-index: 999999;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/loader/Loader.tsx
+++ b/src/components/loader/Loader.tsx
@@ -1,0 +1,5 @@
+import styles from './Loader.module.scss';
+
+export default function Loader() {
+  return <div className={styles.loader} />;
+}

--- a/src/components/users/LoginForm.tsx
+++ b/src/components/users/LoginForm.tsx
@@ -78,7 +78,7 @@ export default function LoginForm() {
 
   return (
     <form className={`${styles.form} ${styles.formLg}`} onSubmit={onSubmit}>
-      <div className={styles.form__title}>회원가입</div>
+      <div className={styles.form__title}>로그인</div>
       <div className={styles.form__block}>
         <label htmlFor="email">이메일</label>
         <input

--- a/src/components/users/LoginForm.tsx
+++ b/src/components/users/LoginForm.tsx
@@ -1,0 +1,142 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import React, { useState } from 'react';
+import { Login, socialLogin } from '../../api/firebase';
+import { getErrorMessage } from '../../util/error';
+import styles from './SingupForm.module.scss';
+
+export default function LoginForm() {
+  const [error, setError] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+
+  const navigate = useNavigate();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { name, value },
+    } = e;
+
+    const emailRegex =
+      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+    const passwordRegEx = /^[A-Za-z0-9]{8,20}$/;
+
+    if (name === 'email') {
+      setEmail(value);
+
+      const isValidEmail = value?.match(emailRegex);
+
+      setError(isValidEmail ? '' : '올바른 이메일이 아닙니다.');
+    }
+
+    if (name === 'password') {
+      setPassword(value);
+
+      const isValidPassword = value?.match(passwordRegEx);
+
+      setError(
+        isValidPassword
+          ? ''
+          : '비밀번호는 영문 대소문자, 숫자를 혼합하여 8~20자로 입력해주세요..',
+      );
+    }
+  };
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await Login(email, password);
+      toast.success('성공적으로 로그인 되었습니다.', {
+        theme: 'dark',
+      });
+      navigate('/');
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage, {
+        theme: 'dark',
+      });
+    }
+  };
+
+  const onClickSocialLogin = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    const { name } = e.currentTarget;
+
+    try {
+      await socialLogin(name);
+      toast.success('로그인 되었습니다.', {
+        theme: 'dark',
+      });
+      navigate('/');
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage, {
+        theme: 'dark',
+      });
+    }
+  };
+
+  return (
+    <form className={`${styles.form} ${styles.formLg}`} onSubmit={onSubmit}>
+      <div className={styles.form__title}>회원가입</div>
+      <div className={styles.form__block}>
+        <label htmlFor="email">이메일</label>
+        <input
+          type="text"
+          name="email"
+          id="email"
+          required
+          value={email}
+          onChange={onChange}
+        />
+      </div>
+      <div className={styles.form__block}>
+        <label htmlFor="password">비밀번호</label>
+        <input
+          type="password"
+          name="password"
+          id="password"
+          required
+          value={password}
+          onChange={onChange}
+        />
+      </div>
+      {error && error?.length > 0 && (
+        <div className={styles.form__block}>
+          <div className={styles.form__error}>{error}</div>
+        </div>
+      )}
+      <div className={styles.form__block}>
+        계정이 없으신가요?
+        <Link to="/users/signup" className={styles.form__link}>
+          회원가입하기
+        </Link>
+      </div>
+      <div className={styles.form__blockLg}>
+        <button type="submit" className={styles.form__btnSubmit}>
+          로그인
+        </button>
+      </div>
+      <div className={styles.form__block}>
+        <button
+          type="button"
+          className={styles.form__btnGoogle}
+          name="google"
+          onClick={onClickSocialLogin}
+        >
+          구글로 로그인하기
+        </button>
+      </div>
+      <div className={styles.form__block}>
+        <button
+          type="button"
+          className={styles.form__btnGithub}
+          name="github"
+          onClick={onClickSocialLogin}
+        >
+          깃허브로 로그인하기
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/users/SignupForm.tsx
+++ b/src/components/users/SignupForm.tsx
@@ -1,0 +1,166 @@
+import { toast } from 'react-toastify';
+import { Link, useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
+import { createUser, socialLogin } from '../../api/firebase';
+import { getErrorMessage } from '../../util/error';
+import styles from './SingupForm.module.scss';
+
+export default function SignupForm() {
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [passwordConfirm, setPasswordConfirm] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  const navigate = useNavigate();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    const emailRegex =
+      /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+    const passwordRegEx = /^[A-Za-z0-9]{8,20}$/;
+
+    if (name === 'email') {
+      setEmail(value);
+
+      const isValidEmail = value?.match(emailRegex);
+
+      setError(isValidEmail ? '' : '올바른 이메일이 아닙니다.');
+    }
+
+    if (name === 'password') {
+      setPassword(value);
+
+      const isValidPassword = value?.match(passwordRegEx);
+
+      setError(
+        isValidPassword
+          ? ''
+          : '비밀번호는 영문 대소문자, 숫자를 혼합하여 8~20자로 입력해주세요..',
+      );
+
+      if (passwordConfirm?.length > 0 && value !== passwordConfirm) {
+        setError('비밀번호와 값이 다릅니다. 다시 확인해주세요');
+      }
+    }
+
+    if (name === 'password_confirm') {
+      setPasswordConfirm(value);
+
+      const isValidPasswordConfirm = value !== password;
+
+      setError(
+        isValidPasswordConfirm
+          ? '비밀번호와 값이 다릅니다. 다시 확인해주세요'
+          : '',
+      );
+    }
+  };
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await createUser(email, password);
+      toast.success('성공적으로 회원가입이 되었습니다.', {
+        theme: 'dark',
+      });
+      navigate('/');
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage, {
+        theme: 'dark',
+      });
+    }
+  };
+  const onClickSocialLogin = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    const { name } = e.currentTarget;
+
+    try {
+      await socialLogin(name);
+      toast.success('로그인 되었습니다.', {
+        theme: 'dark',
+      });
+      navigate('/');
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      toast.error(errorMessage, {
+        theme: 'dark',
+      });
+    }
+  };
+  return (
+    <form className={`${styles.form} ${styles.formLg}`} onSubmit={onSubmit}>
+      <div className={styles.form__title}>회원가입</div>
+      <div className={styles.form__block}>
+        <label htmlFor="email">이메일</label>
+        <input
+          type="text"
+          name="email"
+          id="email"
+          required
+          value={email}
+          onChange={onChange}
+        />
+      </div>
+      <div className={styles.form__block}>
+        <label htmlFor="password">비밀번호</label>
+        <input
+          type="password"
+          name="password"
+          id="password"
+          required
+          value={password}
+          onChange={onChange}
+        />
+      </div>
+      <div className={styles.form__block}>
+        <label htmlFor="password_confirm">비밀번호 확인</label>
+        <input
+          type="password"
+          name="password_confirm"
+          id="password_confirm"
+          required
+          value={passwordConfirm}
+          onChange={onChange}
+        />
+      </div>
+      {error && error?.length > 0 && (
+        <div className={styles.form__block}>
+          <div className={styles.form__error}>{error}</div>
+        </div>
+      )}
+      <div className={styles.form__block}>
+        이미 계정이 있으신가요?
+        <Link to="/users/login" className={styles.form__link}>
+          로그인하기
+        </Link>
+      </div>
+      <div className={styles.form__blockLg}>
+        <button type="submit" className={styles.form__btnSubmit}>
+          회원가입
+        </button>
+      </div>
+      <div className={styles.form__block}>
+        <button
+          type="button"
+          className={styles.form__btnGoogle}
+          name="google"
+          onClick={onClickSocialLogin}
+        >
+          구글로 회원가입하기
+        </button>
+      </div>
+      <div className={styles.form__block}>
+        <button
+          type="button"
+          className={styles.form__btnGithub}
+          name="github"
+          onClick={onClickSocialLogin}
+        >
+          깃허브로 회원가입하기
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/users/SingupForm.module.scss
+++ b/src/components/users/SingupForm.module.scss
@@ -1,0 +1,106 @@
+@import '../../style.scss';
+
+.form {
+  margin: 0 auto;
+  max-width: 680px;
+  padding: 20px;
+  margin-top: 20px;
+
+  &__title {
+    text-align: center;
+    font-size: 24px;
+    font-weight: 700;
+    padding-bottom: 20px;
+  }
+
+  input {
+    height: 50px;
+    padding: 10px;
+    border-radius: 0.3rem;
+    border: 1px solid lightgray;
+    width: 99%;
+    max-width: 680px;
+    font-size: 20px;
+  }
+
+  label {
+    display: block;
+    font-size: 20px;
+    font-weight: 500;
+    margin-bottom: 10px;
+    margin-top: 20px;
+  }
+
+  &__block {
+    margin-top: 20px;
+    width: 100%;
+  }
+
+  &__blockLg {
+    margin-top: 28px;
+    width: 100%;
+  }
+
+  &__link {
+    margin-left: 10px;
+    text-decoration: none;
+    color: $grayText;
+
+    &:hover,
+    &:focus {
+      color: $gray;
+    }
+  }
+
+  &__error {
+    color: red;
+    margin-bottom: 10px;
+  }
+
+  .formLg {
+    margin-top: 28px;
+    width: 100%;
+  }
+
+  &__btnSubmit {
+    @extend .button;
+    width: 100%;
+    height: 48px;
+    font-weight: 600;
+    padding: 10px;
+    cursor: pointer;
+    font-size: 16px;
+    margin: 0 auto;
+    color: white;
+    background-color: $primaryColor;
+
+    &:hover,
+    &:focus {
+      background-color: $activeBorder;
+    }
+  }
+
+  &__btnGoogle {
+    @extend .form__btnSubmit;
+    background-color: $white;
+    color: $activeBorder;
+
+    &:hover,
+    &:focus {
+      background-color: $primaryColor;
+      color: $white;
+    }
+  }
+
+  &__btnGithub {
+    @extend .form__btnSubmit;
+    background-color: $textarea;
+    color: $white;
+
+    &:hover,
+    &:focus {
+      background-color: $activeBg;
+      color: $white;
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import ReactDOM from 'react-dom/client';
-import React from 'react';
 import Home from './pages/home/index.tsx';
 import PostListPage from './pages/posts/index.tsx';
 import PostDetailPage from './pages/posts/detail.tsx';
@@ -13,37 +12,47 @@ import SearchPage from './pages/search/index.tsx';
 import LoginPage from './pages/users/login.tsx';
 import SignupPage from './pages/users/signup.tsx';
 import NotFoundPage from './pages/notFound/index.tsx';
+import MainPage from './pages/main/index.tsx';
 import AppLayout from './components/layout/AppLayout.tsx';
-import './index.scss';
 import { AuthContextProvider } from './components/context/AuthContext.tsx';
+import ProtectedRoute from './components/ProtectedRoute.tsx';
+import './index.scss';
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <AppLayout />, // 최상위 라우트에서 AppLayout 적용
+    element: <AppLayout />,
     errorElement: <NotFoundPage />,
     children: [
-      { index: true, element: <Home /> },
+      {
+        index: true,
+        element: (
+          <ProtectedRoute>
+            <Home />
+          </ProtectedRoute>
+        ),
+      },
       {
         path: 'posts',
         children: [
-          { path: '', element: <PostListPage /> }, // /posts
-          { path: ':id', element: <PostDetailPage /> }, // /posts/:id
-          { path: 'edit/:id', element: <PostEditPage /> }, // /posts/edit/:id
-          { path: 'new', element: <PostNewPage /> }, // /posts/new
+          { path: '', element: <PostListPage /> },
+          { path: ':id', element: <PostDetailPage /> },
+          { path: 'edit/:id', element: <PostEditPage /> },
+          { path: 'new', element: <PostNewPage /> },
         ],
       },
       {
         path: 'users',
         children: [
-          { path: 'login', element: <LoginPage /> }, // /users/login
-          { path: 'signup', element: <SignupPage /> }, // /users/signup
+          { path: '', element: <MainPage /> },
+          { path: 'login', element: <LoginPage /> },
+          { path: 'signup', element: <SignupPage /> },
         ],
       },
-      { path: 'profile', element: <ProfilePage /> }, // /profile
-      { path: 'profile/edit', element: <ProfileEditPage /> }, // /profile/edit
-      { path: 'notifications', element: <NotificationsPage /> }, // /notifications
-      { path: 'search', element: <SearchPage /> }, // /search
+      { path: 'profile', element: <ProfilePage /> },
+      { path: 'profile/edit', element: <ProfileEditPage /> },
+      { path: 'notifications', element: <NotificationsPage /> },
+      { path: 'search', element: <SearchPage /> },
     ],
   },
 ]);

--- a/src/pages/main/MainPage.module.scss
+++ b/src/pages/main/MainPage.module.scss
@@ -1,0 +1,81 @@
+@import '../../style.scss';
+
+.main {
+  display: flex;
+  justify-content: center;
+  width: 100dvw;
+  height: 100dvh;
+
+  &__left {
+    width: 800px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    img {
+      width: 450px;
+      height: 550px;
+      padding-top: 20px;
+    }
+  }
+
+  &__right {
+    width: 800px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 48px 0;
+
+    h1 {
+      display: block;
+      font-size: 64px;
+      margin-bottom: 32px;
+    }
+
+    h2 {
+      display: block;
+      font-size: 31px;
+      font-weight: 700;
+      margin-bottom: 32px;
+    }
+
+    h3 {
+      font-weight: 700;
+      font-size: 17px;
+      margin-bottom: 20px;
+      margin-top: 40px;
+    }
+
+    &__btnSignup {
+      @extend .button;
+      width: 300px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 16px;
+      background-color: $primaryColor;
+      text-decoration: none;
+
+      &:hover {
+        background-color: $activeBorder;
+      }
+    }
+
+    &__btnLogin {
+      @extend .button;
+      width: 300px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-decoration: none;
+      border: 1px solid $white;
+      color: $activeBorder;
+
+      &:hover {
+        background-color: rgba(29, 155, 240, 0.1);
+      }
+    }
+  }
+}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+import styles from './MainPage.module.scss';
+
+export default function MainPage() {
+  return (
+    <div className={styles.main}>
+      <div className={styles.main__left}>
+        <img src="./logo.png" alt="logo" />
+      </div>
+      <div className={styles.main__right}>
+        <h1>지금 일어나고 있는 일</h1>
+        <h2>지금 가입하세요.</h2>
+        <Link to="/users/signup" className={styles.main__right__btnSignup}>
+          계정 만들기
+        </Link>
+        <h3>이미 트위터에 가입하셨나요?</h3>
+        <Link to="/users/login" className={styles.main__right__btnLogin}>
+          로그인
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/users/login.tsx
+++ b/src/pages/users/login.tsx
@@ -1,3 +1,5 @@
+import LoginForm from '../../components/users/LoginForm';
+
 export default function LoginPage() {
-  return <div>LoginPage</div>;
+  return <LoginForm />;
 }

--- a/src/pages/users/signup.tsx
+++ b/src/pages/users/signup.tsx
@@ -1,3 +1,5 @@
+import SignupForm from '../../components/users/SignupForm';
+
 export default function SignupPage() {
-  return <div>SignupPage</div>;
+  return <SignupForm />;
 }

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -1,0 +1,3 @@
+export const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message;
+};


### PR DESCRIPTION
## 작업내용

1. 로그인 하지 않은 유저의 경우 로그인 또는 회원가입을 할 수 있는 페이지로 이동
2. 회원가입 및 로그인 구현
- 기본적인 이메일 / 패스워드로 로그인 또는 회원가입 가능
- SNS 로그인 가능 ( 구글 및 깃허브 로그인 )
3. toast가 생성되지 않는 부분 수정
- App에 작성했던 ToastContainer를 AppLayout로 옮김

  <br/>

## 이미지 첨부

<img width="1471" alt="스크린샷 2024-05-20 오전 11 15 26" src="https://github.com/jm-316/Jwitter/assets/130331748/e412f925-a50b-4e81-b990-d3d0a6e0b854">
<img width="1471" alt="스크린샷 2024-05-20 오전 11 15 32" src="https://github.com/jm-316/Jwitter/assets/130331748/c8bb6c72-7b85-4c74-8084-5ccd4531d8b2">
<img width="1471" alt="스크린샷 2024-05-20 오전 11 17 40" src="https://github.com/jm-316/Jwitter/assets/130331748/6e300397-84bc-41fd-8abc-244b01d64158">



<br/>

## 앞으로의 과제

- post 생성 구현

  <br/>
